### PR TITLE
fix: link username and email findings on a shared site in correlation

### DIFF
--- a/src/osint_casebuilder/modules/correlation.py
+++ b/src/osint_casebuilder/modules/correlation.py
@@ -48,6 +48,19 @@ def extract_entities(finding: dict) -> list:
     elif ftype == "host" and val:
         ents.append(("host", str(val).strip()))
 
+    # account-presence bridge: a maigret username hit, a holehe email-registration,
+    # or an ignorant phone-registration all assert "the target has an account at
+    # this site". Extracting the site host as a shared entity lets a username and an
+    # email/phone landing on the SAME site (e.g. Replit) merge into one identity
+    # cluster — without it they share no entity and split into separate clusters.
+    # Gated to these finding kinds so resolver/lookup sources (e.g. the Email/MX
+    # finding's dns.google) don't leak in as bogus sites.
+    platform = str(finding.get("platform") or "")
+    if ftype == "username" or platform.startswith(("holehe:", "ignorant:")):
+        site = _domain_of(finding.get("source") or "")
+        if site:
+            ents.append(("site", site))
+
     # identity attributes carried in meta
     if meta.get("email") and _EMAIL_RE.match(str(meta["email"])):
         ents.append(("email", _norm(meta["email"])))

--- a/src/tests/test_correlation.py
+++ b/src/tests/test_correlation.py
@@ -64,6 +64,26 @@ class TestExtractEntities(unittest.TestCase):
         self.assertIn(("host", "1.2.3.4"), ents)
         self.assertIn(("domain", "example.com"), ents)
 
+    def test_site_extracted_for_account_presence(self):
+        # a maigret username hit and a holehe email-registration on the same site
+        # both yield the same ("site", host) bridge entity
+        uname = {"type": "username", "value": "derdelean", "platform": "Replit",
+                 "source": "https://replit.com/@derdelean", "meta": {}}
+        holehe = {"type": "email", "value": "x@gmail.com", "platform": "holehe:replit",
+                  "source": "https://replit.com", "meta": {"registered": True}}
+        self.assertIn(("site", "replit.com"), extract_entities(uname))
+        self.assertIn(("site", "replit.com"), extract_entities(holehe))
+
+    def test_site_not_extracted_for_resolver_lookup(self):
+        # the Email/MX finding's source is a DoH resolver, not the target's site
+        self.assertNotIn(
+            ("site", "dns.google"),
+            extract_entities({"type": "email", "value": "linus@kernel.org",
+                              "platform": "Email/MX",
+                              "source": "https://dns.google/resolve?name=kernel.org&type=MX",
+                              "meta": {"domain": "kernel.org"}}),
+        )
+
 
 class TestCorrelate(unittest.TestCase):
     def setUp(self):
@@ -90,6 +110,36 @@ class TestCorrelate(unittest.TestCase):
         self.assertEqual(s["distinct_entities"], 0)
         self.assertEqual(s["clusters"], 0)
         self.assertEqual(s["corroborated"], [])
+
+
+class TestSiteBridge(unittest.TestCase):
+    """A username hit and an email/phone registration on the SAME site must merge
+    into one identity cluster (the username↔email cross-type link)."""
+
+    UNAME_REPLIT = {"type": "username", "value": "derdelean", "platform": "Replit",
+                    "source": "https://replit.com/@derdelean", "meta": {}}
+    HOLEHE_REPLIT = {"type": "email", "value": "x@gmail.com", "platform": "holehe:replit",
+                     "source": "https://replit.com", "meta": {"registered": True}}
+
+    def test_username_and_email_merge_via_site(self):
+        # alone the two share no entity (username vs email) — only the site bridges
+        s = correlate([self.UNAME_REPLIT, self.HOLEHE_REPLIT])
+        self.assertEqual(s["clusters"], 1)
+
+    def test_shared_site_is_corroborated(self):
+        s = correlate([self.UNAME_REPLIT, self.HOLEHE_REPLIT])
+        site = [c for c in s["corroborated"]
+                if c["type"] == "site" and c["value"] == "replit.com"]
+        self.assertEqual(len(site), 1)
+        self.assertEqual(site[0]["count"], 2)
+        self.assertEqual(sorted(site[0]["platforms"]), ["Replit", "holehe:replit"])
+
+    def test_different_sites_do_not_merge(self):
+        # username on replit + email registered on twitter → no bridge, 2 clusters
+        holehe_tw = {"type": "email", "value": "x@gmail.com", "platform": "holehe:twitter",
+                     "source": "https://twitter.com", "meta": {"registered": True}}
+        s = correlate([self.UNAME_REPLIT, holehe_tw])
+        self.assertEqual(s["clusters"], 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The correlation engine extracted each finding's *subject* — a username **or** an email — but never the **site the finding is about**. So a Maigret `username` hit ("derdelean on Replit") and a holehe email-registration ("this email is registered on Replit") shared no entity and split into separate identity clusters, even though they point at the same account. A live self-test reported **2 clusters** where there should be 1.

## Fix

`extract_entities` now emits a `("site", host)` bridge entity for account-presence findings — Maigret `username` hits, `holehe:*`, and `ignorant:*` — derived from the finding's source host. Gated to those kinds so resolver sources (e.g. the `Email/MX` finding's `dns.google`) don't leak in as bogus sites. When a username and an email/phone land on the same site, that site is a shared entity and union-find merges them.

## Verification

- Re-correlating the real saved case: **clusters 2 → 1**, with `replit.com ×2 [Replit, holehe:replit]` surfaced as a corroborated cross-type link.
- 5 new tests (site extraction, resolver-exclusion, merge-to-1-cluster, corroboration shape, different-sites-don't-merge).
- Full suite: 69 passing.