### PR TITLE
chore: gitignore .DS_Store and generated reports/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ osint_casebuilder/__pycache__/
 __pycache__/
 .vscode/
 
+# macOS
+.DS_Store
+
 # Generated artifacts
 *.db
 *_graph.html
+reports/


### PR DESCRIPTION
Stops macOS `.DS_Store` files and the CWD-relative `reports/` output directory from showing up as untracked noise.

- `.DS_Store` — macOS folder metadata (was appearing at repo root and `src/`).
- `reports/` — generated Markdown/JSON report output (written to `src/reports/` on each run).

`*.db` and `*_graph.html` were already ignored; this rounds out the generated-artifact set.